### PR TITLE
keep loras loaded for repeat predictions

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -61,7 +61,7 @@ class Predictor(BasePredictor):
             print("Loading LoRA weights")
             weights = str(weights)
             if weights == self.get_loaded_weights_string(pipe):
-                print("weights already loaded, returning")
+                print("weights already loaded!")
                 return
             pipe.unload_lora_weights()
 


### PR DESCRIPTION
Should improve performance when we have repeated predictions w/the same hotswap weights. 