### PR TITLE
Share pipeline components

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -16,11 +16,8 @@ from diffusers.pipelines.stable_diffusion.safety_checker import (
     StableDiffusionSafetyChecker,
 )
 
-# MODEL_URL_DEV = "https://weights.replicate.delivery/default/black-forest-labs/FLUX.1-dev/model-cache.tar"
-MODEL_URL_DEV = (
-    "https://weights.replicate.delivery/default/black-forest-labs/FLUX.1-dev/files.tar"
-)
-MODEL_URL_SCHNELL = "https://weights.replicate.delivery/default/black-forest-labs/FLUX.1-schnell/files.tar"
+MODEL_URL_DEV = "https://weights.replicate.delivery/default/black-forest-labs/FLUX.1-dev/files.tar"
+MODEL_URL_SCHNELL = "https://weights.replicate.delivery/default/black-forest-labs/FLUX.1-schnell/slim.tar"
 SAFETY_CACHE = "safety-cache"
 FEATURE_EXTRACTOR = "/src/feature-extractor"
 SAFETY_URL = "https://weights.replicate.delivery/default/sdxl/safety-1.0.tar"
@@ -116,9 +113,13 @@ class Predictor(BasePredictor):
 
         print("Loading Flux schnell pipeline")
         if not os.path.exists("FLUX.1-schnell"):
-            download_weights(MODEL_URL_SCHNELL, ".")
+            download_weights(MODEL_URL_SCHNELL, "FLUX.1-schnell")
         self.schnell_pipe = FluxPipeline.from_pretrained(
             "FLUX.1-schnell",
+            text_encoder=self.dev_pipe.text_encoder,
+            text_encoder_2=self.dev_pipe.text_encoder_2,
+            tokenizer=self.dev_pipe.tokenizer,
+            tokenizer_2=self.dev_pipe.tokenizer_2,
             torch_dtype=torch.bfloat16,
         ).to("cuda")
         self.schnell_weights = ""


### PR DESCRIPTION
Load shared pipeline components for Dev & Schnell

Saves 10Gb VRAM and ~15 seconds of cold boot times

Staging area to check setup logs: [replicate-internal/flux-fine-tuner](https://replicate.com/replicate-internal/flux-fine-tuner/versions/a09917fcb763a5992f77e8816305b5e34d72cd304b98c6bf4ca5261d74d312da/setup-logs)

Download times Before:
![Screenshot 2024-08-19 at 10 50 08 PM](https://github.com/user-attachments/assets/136098f7-3fe4-4d99-98f9-d1c9d982670e)
Download times After:
![Screenshot 2024-08-19 at 11 10 42 PM](https://github.com/user-attachments/assets/2c28d261-a037-47ba-831f-d6c9dbfef83d)

