### PR TITLE
Use `zipfile.is_zipfile` to validate `input_images`

### DIFF
--- a/train.py
+++ b/train.py
@@ -18,7 +18,7 @@ import torch
 from typing import OrderedDict, Optional
 import shutil
 import subprocess
-from zipfile import ZipFile
+from zipfile import ZipFile, is_zipfile
 from cog import BaseModel, Input, Path, Secret
 from huggingface_hub import HfApi
 
@@ -293,7 +293,7 @@ def handle_hf_readme(lora_dir: Path, hf_repo_id: str, trigger_word: Optional[str
 
 
 def extract_zip(input_images: Path, input_dir: Path):
-    if not input_images.name.endswith(".zip"):
+    if not is_zipfile(input_images):
         raise ValueError("input_images must be a zip file")
 
     input_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
GitHub users are reporting errors using the [flux fine-tuner](https://replicate.com/ostris/flux-dev-lora-trainer/train) with the Python SDK.

The current check for a `.zip` suffix is likely to produce false negatives. The [zipfile.is_zipfile](https://docs.python.org/3/library/zipfile.html#zipfile.is_zipfile) method is a better way to determine this. 
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d91be7e5a52882e4d77829af840e4ff7ca41f1e0  | 
|--------|--------|

### Summary:
Replaced `.zip` suffix check with `zipfile.is_zipfile` in `extract_zip` function to ensure `input_images` is a valid zip file.

**Key points**:
- Replaced `.zip` suffix check with `zipfile.is_zipfile` in `extract_zip` function in `train.py`.
- Ensures `input_images` is a valid zip file, preventing false negatives.
- Imports `is_zipfile` from `zipfile` module.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->