### PR TITLE
Checksum for Dev weights

### DIFF
--- a/train.py
+++ b/train.py
@@ -313,9 +313,6 @@ def clean_up():
     if OUTPUT_DIR.exists():
         shutil.rmtree(OUTPUT_DIR)
 
-    if WEIGHTS_PATH.exists():
-        shutil.rmtree(WEIGHTS_PATH)
-
 
 def download_huggingface_lora(hf_lora_url: str, output_path: str):
     if (
@@ -339,8 +336,18 @@ def download_huggingface_lora(hf_lora_url: str, output_path: str):
     os.system(f"tar -cvf {output_path} {lora_path}")
 
 
+def calculate_checksum(path):
+    cmd = f"find {path} -type f -exec sha256sum {{}} \\; | sort -k 2 | sha256sum | cut -d' ' -f1"
+    result = subprocess.run(cmd, shell=True, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
 def download_weights():
-    if not WEIGHTS_PATH.exists():
+    if WEIGHTS_PATH.exists():
+        print("Dev weights found, calculating checksum")
+        dev_checksum = calculate_checksum(WEIGHTS_PATH)
+        print("CHECKSUM: ", dev_checksum)
+    if not WEIGHTS_PATH.exists() or (dev_checksum != "3d84d0fbacd9c26a0ec9e36748f2760110ee9a5da56a089b10c72dd3735c1ec0"):
         t1 = time.time()
         subprocess.check_output(
             [


### PR DESCRIPTION
Checksum check for Dev weights

We need to fix the flux-fine-tuner in downloading weights before the pod is marked as ready.
We cleared the weights folder to prevent a training run from stopping halfway after being cancelled and erroring out on the next training run. 
This 2min checksum should be faster than re-downloading the weights (which can take up to 40min)
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 48fce78a7060745b9cf4105f8b9eefc7284da86b  | 
|--------|--------|

### Summary:
This PR adds checksum verification for development weights in `train.py` to ensure validity before training, re-downloading if mismatched.

**Key points**:
- Added `calculate_checksum` function in `train.py` to compute SHA256 checksum of files in a directory.
- Modified `download_weights` function in `train.py` to check if `WEIGHTS_PATH` exists and verify its checksum.
- If the checksum of `WEIGHTS_PATH` does not match the expected value, the weights are re-downloaded.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->