### PR TITLE
Improve the zipfile check, as s3 signed urls do not end with .zip

### DIFF
--- a/train.py
+++ b/train.py
@@ -98,7 +98,9 @@ def train(
     ),
     lora_rank: int = Input(
         description="Higher ranks take longer to train but can capture more complex features. Caption quality is more important for higher ranks.",
-        default=16, ge=1, le=128
+        default=16,
+        ge=1,
+        le=128,
     ),
     optimizer: str = Input(
         description="Optimizer to use for training. Supports: prodigy, adam8bit, adamw8bit, lion8bit, adam, adamw, lion, adagrad, adafactor.",


### PR DESCRIPTION
This pull request was created in response to a customer issue.

They are unable to pass-in zip files that live behind a bunch of s3 signed URL query params, where the urls do not end with the `.zip` file extension.

This change uses the `zipfile.is_zipfile` function, which should allow for non-standard filenames and urls to be used.
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 038b3e5f713ccf5d85dfdb4b5ffaa2133a4d13fa  | 
|--------|--------|

### Summary:
The PR updates `extract_zip` in `train.py` to use `zipfile.is_zipfile`, fixing S3 signed URL issues without `.zip` extension.

**Key points**:
- Update `extract_zip` in `train.py` to use `zipfile.is_zipfile` for zip validation.
- Allows validation for URLs without `.zip` extension.
- Fixes issue with S3 signed URLs not ending in `.zip`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->