### PR TITLE
remove black linting, as ruff already covers the bases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,10 +26,6 @@ jobs:
       run: |
         ruff check --exclude=ai-toolkit/ --exclude=LLaVA/ --ignore=E402
 
-    - name: Run black
-      run: |
-        black --check --exclude="ai-toolkit/|LLaVA/" .
-
   unit-test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The `black` linter seems to be throwing false positives, and we're already linting with `ruff`, so should be safe to remove it.  
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 55b016d0451fc1ea313fade85db9e57ab338df52  | 
|--------|--------|

### Summary:
Remove `black` linter from CI workflow as `ruff` already covers linting.

**Key points**:
- Removed `black` linter from `.github/workflows/ci.yaml`.
- `ruff` linter already covers necessary linting checks.
- Simplifies CI workflow by removing redundant linting step.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->