### PR TITLE
Use ruff to do formatting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,13 +22,13 @@ jobs:
       run: |
         pip install -r requirements-test.txt
 
-    - name: Run ruff
+    - name: Run ruff linter
       run: |
         ruff check --exclude=ai-toolkit/ --exclude=LLaVA/ --ignore=E402
 
-    - name: Run black
+    - name: Run ruff formatter
       run: |
-        black --check --exclude="ai-toolkit/|LLaVA/" .
+        ruff format --diff --exclude=ai-toolkit/ --exclude=LLaVA/
 
   unit-test:
     runs-on: ubuntu-latest

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
 pytest
 requests-mock
 ruff
-black


### PR DESCRIPTION
Uses `--diff` to make it actionable
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e2f385e8c18fe04a89c58f5d00aa5d8b4ebf8ee9  | 
|--------|--------|

### Summary:
This PR updates the CI workflow to use `ruff` for linting and formatting, replacing `black`, and modifies related files accordingly.

**Key points**:
- Update CI workflow to use `ruff` for linting and formatting, replacing `black`.
- Modify related files accordingly.
- Use `ruff format --diff` instead of `black --check`.
- Exclude `ai-toolkit/` and `LLaVA/` from `ruff` checks.
- Remove `black` from `requirements-test.txt`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->