### PR TITLE
remove TOK as default value of trigger_word

### DIFF
--- a/train.py
+++ b/train.py
@@ -102,8 +102,7 @@ def train(
         default=None,
     ),
     trigger_word: str = Input(
-        description="The trigger word refers to the object, style or concept you are training on. Pick a string that isn’t a real word, like TOK or something related to what’s being trained, like CYBRPNK. The trigger word you specify here will be associated with all images during training. Then when you use your LoRA, you can include the trigger word in prompts to help activate the LoRA.",
-        default="TOK",
+        description="The trigger word refers to the object, style or concept you are training on. Pick a string that isn’t a real word, but is ideally related to what’s being trained, like CYBRPNK. The trigger word you specify here will be associated with all images during training. Then when you use your LoRA, you can include the trigger word in prompts to help activate the LoRA.",
     ),
     autocaption: bool = Input(
         description="Automatically caption images using Llava v1.5 13B", default=True


### PR DESCRIPTION
`TOK` is not a good default trigger word, because the latent space is already polluted with for it.

This PR proposes to remove the default, so users are forced to pick a unique trigger word.

---

From the [Cog docs](https://cog.run/training/#inputkwargs):

> `default`: A default value to set the input to. If this argument is not passed, the input is required. If it is explicitly set to None, the input is optional.