### PR TITLE
Add HF upload to train test

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -36,6 +36,12 @@ jobs:
       run: |
         pip install git+https://github.com/replicate/cog-safe-push.git
 
+    - name: "Inject secrets into cog-safe-push.yaml"
+      env:
+        HF_TOKEN: ${{ secrets.HF_WRITE_TO_TEST_FINE_TUNER_INTEGRATION }}
+      run: |
+        envsubst < cog-safe-push.yaml.tpl > cog-safe-push.yaml
+
     - name: Run cog-safe-push to test the trainer and predictor and optionally push to production
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/cog-safe-push.yaml.tpl
+++ b/cog-safe-push.yaml.tpl
@@ -112,8 +112,10 @@ train:
 
     # tiny training with autocaption
     - inputs:
-        input_images: "https://replicate.delivery/pbxt/LbXqvBzG3Bfo6CDkIkBNo8a8v6GWZGQrqxBrgeRpaQ1knkyD/me-tiny.zip"
+        input_images: https://replicate.delivery/pbxt/LbXqvBzG3Bfo6CDkIkBNo8a8v6GWZGQrqxBrgeRpaQ1knkyD/me-tiny.zip
         steps: 50
         autocaption: true
         trigger_word: NDRS
+        hf_repo_id: replicate/test-flux-fine-tuner-integration
+        hf_token: "$HF_TOKEN"
       match_prompt: "A dictionary of a version and weights which are a .tar file"


### PR DESCRIPTION
This will use a finegrained HF write secret to push the test training to huggingface.

It does not currently fail if the HF push fails (as we intentionally catch errors around this).

We can however still manually check the logs and see if the lora correctly uploaded.