### PR TITLE
enhance: change submodule URLs from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ai-toolkit"]
 	path = ai-toolkit
-	url = git@github.com:ostris/ai-toolkit.git
+	url = https://github.com/ostris/ai-toolkit.git
 [submodule "LLaVA"]
 	path = LLaVA
-	url = git@github.com:haotian-liu/LLaVA.git
+	url = https://github.com/haotian-liu/LLaVA.git


### PR DESCRIPTION
This PR updates the submodule URLs in the `.gitmodules` file to use HTTPS instead of SSH.
This will allow users who do not have SSH keys configured to clone the submodules more easily.

Submodules affected:
- LLaVA: from `git@github.com:haotian-liu/LLaVA.git` to `https://github.com/haotian-liu/LLaVA.git`
- ai-toolkit: from `git@github.com:ostris/ai-toolkit.git` to `https://github.com/ostris/ai-toolkit.git`

This change should improve accessibility for contributors and users.
