### PR TITLE
patching lora load for faster loading

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,7 +15,7 @@ __pycache__
 
 # Exclude Python virtual environment
 /venv
-
+/weights-cache
 
 FLUX.1-dev
 FLUX.1-schnell

--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,4 @@ input_images/
 safety-cache/
 falcon-cache/
 output/
+weights-cache/

--- a/cog-safe-push.yaml.tpl
+++ b/cog-safe-push.yaml.tpl
@@ -34,7 +34,7 @@ predict:
         image: "https://storage.googleapis.com/cog-safe-push-public/fast-car.jpg"
         prompt_strength: 0.9
         seed: 12919
-      match_url: https://storage.googleapis.com/replicate-test-flux-finer-tuner/test-outputs/img2img.jpg
+      match_url: https://replicate.delivery/yhqm/zekZzRptTet51UvOUHUH0fnT04taL9seSvRQuP0p7fPnvoIcC/out-0.jpg
 
     # inpainting
     - inputs:
@@ -80,7 +80,7 @@ predict:
         seed: 16726
         output_format: jpg
         replicate_weights: https://replicate.delivery/yhqm/MHJmIF7zlLKXPNN9LKN5yxYUuC7SyzKjMBtqeVwUGdPCpqqJA/trained_model.tar
-      match_url: https://storage.googleapis.com/replicate-test-flux-finer-tuner/test-outputs/schnell.jpg
+      match_url: https://replicate.delivery/yhqm/rQhMIg6dhLYVJ5gXWfZI4Ik1DF9cGV7pm8UN0DKmpWDfJGhTA/out-0.jpg
 
     # extra lora
     - inputs:

--- a/cog.yaml
+++ b/cog.yaml
@@ -38,7 +38,7 @@ build:
     - "lpips==0.1.4"
     - "optimum-quanto==0.2.4"
     - "sentencepiece==0.2.0"
-    - "peft==0.12.0"
+    - "peft==0.13.0"
 
     # llava
     - "deepspeed==0.9.5"

--- a/lora_loading_patch.py
+++ b/lora_loading_patch.py
@@ -1,3 +1,4 @@
+# ruff: noqa
 from diffusers.utils import convert_unet_state_dict_to_peft, get_peft_kwargs, is_peft_version, get_adapter_name, logging
 
 logger = logging.get_logger(__name__)

--- a/lora_loading_patch.py
+++ b/lora_loading_patch.py
@@ -1,10 +1,19 @@
 # ruff: noqa
-from diffusers.utils import convert_unet_state_dict_to_peft, get_peft_kwargs, is_peft_version, get_adapter_name, logging
+from diffusers.utils import (
+    convert_unet_state_dict_to_peft,
+    get_peft_kwargs,
+    is_peft_version,
+    get_adapter_name,
+    logging,
+)
 
 logger = logging.get_logger(__name__)
 
+
 # patching inject_adapter_in_model and load_peft_state_dict with low_cpu_mem_usage=True until it's merged into diffusers
-def load_lora_into_transformer(cls, state_dict, network_alphas, transformer, adapter_name=None, _pipeline=None):
+def load_lora_into_transformer(
+    cls, state_dict, network_alphas, transformer, adapter_name=None, _pipeline=None
+):
     """
     This will load the LoRA layers specified in `state_dict` into `transformer`.
 
@@ -29,7 +38,9 @@ def load_lora_into_transformer(cls, state_dict, network_alphas, transformer, ada
 
     transformer_keys = [k for k in keys if k.startswith(cls.transformer_name)]
     state_dict = {
-        k.replace(f"{cls.transformer_name}.", ""): v for k, v in state_dict.items() if k in transformer_keys
+        k.replace(f"{cls.transformer_name}.", ""): v
+        for k, v in state_dict.items()
+        if k in transformer_keys
     }
 
     if len(state_dict.keys()) > 0:
@@ -50,10 +61,20 @@ def load_lora_into_transformer(cls, state_dict, network_alphas, transformer, ada
 
         if network_alphas is not None and len(network_alphas) >= 1:
             prefix = cls.transformer_name
-            alpha_keys = [k for k in network_alphas.keys() if k.startswith(prefix) and k.split(".")[0] == prefix]
-            network_alphas = {k.replace(f"{prefix}.", ""): v for k, v in network_alphas.items() if k in alpha_keys}
+            alpha_keys = [
+                k
+                for k in network_alphas.keys()
+                if k.startswith(prefix) and k.split(".")[0] == prefix
+            ]
+            network_alphas = {
+                k.replace(f"{prefix}.", ""): v
+                for k, v in network_alphas.items()
+                if k in alpha_keys
+            }
 
-        lora_config_kwargs = get_peft_kwargs(rank, network_alpha_dict=network_alphas, peft_state_dict=state_dict)
+        lora_config_kwargs = get_peft_kwargs(
+            rank, network_alpha_dict=network_alphas, peft_state_dict=state_dict
+        )
         if "use_dora" in lora_config_kwargs:
             if lora_config_kwargs["use_dora"] and is_peft_version("<", "0.9.0"):
                 raise ValueError(
@@ -69,10 +90,16 @@ def load_lora_into_transformer(cls, state_dict, network_alphas, transformer, ada
 
         # In case the pipeline has been already offloaded to CPU - temporarily remove the hooks
         # otherwise loading LoRA weights will lead to an error
-        is_model_cpu_offload, is_sequential_cpu_offload = cls._optionally_disable_offloading(_pipeline)
+        is_model_cpu_offload, is_sequential_cpu_offload = (
+            cls._optionally_disable_offloading(_pipeline)
+        )
 
-        inject_adapter_in_model(lora_config, transformer, adapter_name=adapter_name, low_cpu_mem_usage=True)
-        incompatible_keys = set_peft_model_state_dict(transformer, state_dict, adapter_name, low_cpu_mem_usage=True)
+        inject_adapter_in_model(
+            lora_config, transformer, adapter_name=adapter_name, low_cpu_mem_usage=True
+        )
+        incompatible_keys = set_peft_model_state_dict(
+            transformer, state_dict, adapter_name, low_cpu_mem_usage=True
+        )
 
         if incompatible_keys is not None:
             # check only for unexpected keys

--- a/lora_loading_patch.py
+++ b/lora_loading_patch.py
@@ -1,0 +1,90 @@
+from diffusers.utils import convert_unet_state_dict_to_peft, get_peft_kwargs, is_peft_version, get_adapter_name, logging
+
+logger = logging.get_logger(__name__)
+
+# patching inject_adapter_in_model and load_peft_state_dict with low_cpu_mem_usage=True until it's merged into diffusers
+def load_lora_into_transformer(cls, state_dict, network_alphas, transformer, adapter_name=None, _pipeline=None):
+    """
+    This will load the LoRA layers specified in `state_dict` into `transformer`.
+
+    Parameters:
+        state_dict (`dict`):
+            A standard state dict containing the lora layer parameters. The keys can either be indexed directly
+            into the unet or prefixed with an additional `unet` which can be used to distinguish between text
+            encoder lora layers.
+        network_alphas (`Dict[str, float]`):
+            The value of the network alpha used for stable learning and preventing underflow. This value has the
+            same meaning as the `--network_alpha` option in the kohya-ss trainer script. Refer to [this
+            link](https://github.com/darkstorm2150/sd-scripts/blob/main/docs/train_network_README-en.md#execute-learning).
+        transformer (`SD3Transformer2DModel`):
+            The Transformer model to load the LoRA layers into.
+        adapter_name (`str`, *optional*):
+            Adapter name to be used for referencing the loaded adapter model. If not specified, it will use
+            `default_{i}` where i is the total number of adapters being loaded.
+    """
+    from peft import LoraConfig, inject_adapter_in_model, set_peft_model_state_dict
+
+    keys = list(state_dict.keys())
+
+    transformer_keys = [k for k in keys if k.startswith(cls.transformer_name)]
+    state_dict = {
+        k.replace(f"{cls.transformer_name}.", ""): v for k, v in state_dict.items() if k in transformer_keys
+    }
+
+    if len(state_dict.keys()) > 0:
+        # check with first key if is not in peft format
+        first_key = next(iter(state_dict.keys()))
+        if "lora_A" not in first_key:
+            state_dict = convert_unet_state_dict_to_peft(state_dict)
+
+        if adapter_name in getattr(transformer, "peft_config", {}):
+            raise ValueError(
+                f"Adapter name {adapter_name} already in use in the transformer - please select a new adapter name."
+            )
+
+        rank = {}
+        for key, val in state_dict.items():
+            if "lora_B" in key:
+                rank[key] = val.shape[1]
+
+        if network_alphas is not None and len(network_alphas) >= 1:
+            prefix = cls.transformer_name
+            alpha_keys = [k for k in network_alphas.keys() if k.startswith(prefix) and k.split(".")[0] == prefix]
+            network_alphas = {k.replace(f"{prefix}.", ""): v for k, v in network_alphas.items() if k in alpha_keys}
+
+        lora_config_kwargs = get_peft_kwargs(rank, network_alpha_dict=network_alphas, peft_state_dict=state_dict)
+        if "use_dora" in lora_config_kwargs:
+            if lora_config_kwargs["use_dora"] and is_peft_version("<", "0.9.0"):
+                raise ValueError(
+                    "You need `peft` 0.9.0 at least to use DoRA-enabled LoRAs. Please upgrade your installation of `peft`."
+                )
+            else:
+                lora_config_kwargs.pop("use_dora")
+        lora_config = LoraConfig(**lora_config_kwargs)
+
+        # adapter_name
+        if adapter_name is None:
+            adapter_name = get_adapter_name(transformer)
+
+        # In case the pipeline has been already offloaded to CPU - temporarily remove the hooks
+        # otherwise loading LoRA weights will lead to an error
+        is_model_cpu_offload, is_sequential_cpu_offload = cls._optionally_disable_offloading(_pipeline)
+
+        inject_adapter_in_model(lora_config, transformer, adapter_name=adapter_name, low_cpu_mem_usage=True)
+        incompatible_keys = set_peft_model_state_dict(transformer, state_dict, adapter_name, low_cpu_mem_usage=True)
+
+        if incompatible_keys is not None:
+            # check only for unexpected keys
+            unexpected_keys = getattr(incompatible_keys, "unexpected_keys", None)
+            if unexpected_keys:
+                logger.warning(
+                    f"Loading adapter weights from state_dict led to unexpected keys not found in the model: "
+                    f" {unexpected_keys}. "
+                )
+
+        # Offload back.
+        if is_model_cpu_offload:
+            _pipeline.enable_model_cpu_offload()
+        elif is_sequential_cpu_offload:
+            _pipeline.enable_sequential_cpu_offload()
+        # Unsafe code />

--- a/predict.py
+++ b/predict.py
@@ -102,7 +102,9 @@ class Predictor(BasePredictor):
             "FLUX.1-dev",
             torch_dtype=torch.bfloat16,
         ).to("cuda")
-        dev_pipe.__class__.load_lora_into_transformer = classmethod(load_lora_into_transformer)
+        dev_pipe.__class__.load_lora_into_transformer = classmethod(
+            load_lora_into_transformer
+        )
 
         print("Loading Flux schnell pipeline")
         if not FLUX_SCHNELL_PATH.exists():
@@ -133,7 +135,9 @@ class Predictor(BasePredictor):
             tokenizer=dev_pipe.tokenizer,
             tokenizer_2=dev_pipe.tokenizer_2,
         ).to("cuda")
-        dev_img2img_pipe.__class__.load_lora_into_transformer = classmethod(load_lora_into_transformer)
+        dev_img2img_pipe.__class__.load_lora_into_transformer = classmethod(
+            load_lora_into_transformer
+        )
 
         print("Loading Flux schnell img2img pipeline")
         schnell_img2img_pipe = FluxImg2ImgPipeline(
@@ -162,7 +166,9 @@ class Predictor(BasePredictor):
             tokenizer=dev_pipe.tokenizer,
             tokenizer_2=dev_pipe.tokenizer_2,
         ).to("cuda")
-        dev_inpaint_pipe.__class__.load_lora_into_transformer = classmethod(load_lora_into_transformer)
+        dev_inpaint_pipe.__class__.load_lora_into_transformer = classmethod(
+            load_lora_into_transformer
+        )
 
         print("Loading Flux schnell inpaint pipeline")
         schnell_inpaint_pipe = FluxInpaintPipeline(

--- a/ruff.toml
+++ b/ruff.toml
@@ -27,7 +27,7 @@ exclude = [
     "site-packages",
     "venv",
     "ai-toolkit",
-    "LLaVA"
+    "LLaVA",
 ]
 
 # Same as Black.


### PR DESCRIPTION
Profiled lora loading in prod to see what was taking so long - it looks like our old nemesis `kaiming_uniform`, and other such functions that are used to randomly initialize empty tensors.

conveniently, someone [just pushed functionality to peft](https://github.com/huggingface/peft/pull/1961) to disable this. So we don't have to get too wild to turn it off; we just need to patch `load_lora_into_transformer` to take advantage of that functionality until it's integrated into diffusers.

That's what this PR does. With this I saw lora load times (after download) drop from about [10 seconds](https://replicate.com/p/684y0srg3nrm00cj67sr7bg7am) to about [1.2 seconds](https://replicate.com/p/0kq84cyp9srm60cj68ast2sgyc). Tested locally w/dev and schnell.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Patch `load_lora_into_transformer` to use `low_cpu_mem_usage=True`, significantly reducing LoRA load times, and update dependencies accordingly.
> 
>   - **Behavior**:
>     - Patch `load_lora_into_transformer` in `lora_loading_patch.py` to use `low_cpu_mem_usage=True`, reducing LoRA load times from ~10s to ~1.2s.
>     - Update `predict.py` to use the patched `load_lora_into_transformer` for `FluxPipeline`, `FluxImg2ImgPipeline`, and `FluxInpaintPipeline`.
>   - **Dependencies**:
>     - Upgrade `peft` version from `0.12.0` to `0.13.0` in `cog.yaml`.
>   - **Misc**:
>     - Add `/weights-cache` to `.dockerignore`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=replicate%2Fflux-fine-tuner&utm_source=github&utm_medium=referral)<sup> for f53e34cd174091777d9bc4900cc1d8401b359c5b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->