### PR TITLE
feat: improve captioner prompt

### DIFF
--- a/caption.py
+++ b/caption.py
@@ -47,13 +47,13 @@ weights = [
 ]
 
 PROMPT = """
-Write a four sentence caption for this image. In the first sentence describe the style and type (painting, photo, etc) of the image. Describe in the remaining sentences the contents and composition of the image. Only use language that would be used to prompt a text to image model. Do not include usage. Comma separate keywords rather than using "or". Precise composition is important. Avoid phrases like "conveys a sense of" and "capturing the", just use the terms themselves.
+Write a four sentence caption for this image. In the first sentence describe the style and type (painting, photo, etc) of the image. Describe in the remaining sentences the contents and composition of the image. Only use language that would be used to prompt a text to image model. Do not include usage. Comma separate keywords rather than using "or". Precise composition is important. Avoid phrases like "conveys a sense of" and "capturing the", just use the terms themselves. If there is any text in the image, include it in an optional final sentence, transcribing the text exactly and describing its styling and placement.
 
 Good examples are:
 
-"Photo of an alien woman with a glowing halo standing on top of a mountain, wearing a white robe and silver mask in the futuristic style with futuristic design, sky background, soft lighting, dynamic pose, a sense of future technology, a science fiction movie scene rendered in the Unreal Engine."
+"Photo of an alien woman with a glowing halo standing on top of a mountain, wearing a white robe and silver mask in the futuristic style with futuristic design, sky background, soft lighting, dynamic pose, a sense of future technology, a science fiction movie scene rendered in the Unreal Engine. Text: 'The Future is Now', in a bold sans-serif font with a futuristic glow at the top right corner of the image, large."
 
-"A scene from the cartoon series Masters of the Universe depicts Man-At-Arms wearing a gray helmet and gray armor with red gloves. He is holding an iron bar above his head while looking down on Orko, a pink blob character. Orko is sitting behind Man-At-Arms facing left on a chair. Both characters are standing near each other, with Orko inside a yellow chestplate over a blue shirt and black pants. The scene is drawn in the style of the Masters of the Universe cartoon series."
+"A scene from the cartoon series Masters of the Universe depicts Man-At-Arms wearing a gray helmet and gray armor with red gloves. He is holding an iron bar above his head while looking down on Orko, a pink blob character. Orko is sitting behind Man-At-Arms facing left on a chair. Both characters are standing near each other, with Orko inside a yellow chestplate over a blue shirt and black pants. The scene is drawn in the style of the Masters of the Universe cartoon series. Text: "What did he mean by this?" in a yellow font on black text at the bottom of the image, like a TV."
 
 "An emoji, digital illustration, playful, whimsical. A cartoon zombie character with green skin and tattered clothes reaches forward with two hands, they have green skin, messy hair, an open mouth and gaping teeth, one eye is half closed."
 """.strip()


### PR DESCRIPTION
Flux is pretty good at text, but our autocaptioner doesn't know to transcribe text from training images. I tested it by recaptioning a dataset with fofr/batch-image-captioning using a modified version of this prompt, and got much improved legibility and steerability in the new version. Partly this is just because GPT-4o is a better VLM than LLaVA-13b, but I think this will still improve outputs for the autocaptioner.

Prediction examples: [before](https://replicate.com/p/rtz5qdn3rhrma0cmc7d8a86254) | [after](https://replicate.com/p/0hxknnkdmsrm80cmc7f94fj7ag)

If we want to improve this further, we could use BLIP-3 as a captioner instead of LLaVA. See these results for a test image:

[LLaVA 13b (old prompt)](https://replicate.com/yorickvp/llava-13b?prediction=xrh0fm4gyxrmc0cmc7sb6sssf8)
[LLavA 13b](https://replicate.com/p/vfjenw5d59rme0cmc7qs678f84)
[Molmo-7b](https://replicate.com/p/5k4rv7gw65rmc0cmc7qr743s9r)
[BLIP-3](https://replicate.com/p/901ajqf01drj40cmc7q8w6bj1w)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves image captioning by updating the prompt to include transcription of text from images in `caption.py`.
> 
>   - **Behavior**:
>     - Updated `PROMPT` in `caption.py` to include transcription of text from images in an optional final sentence, describing its styling and placement.
>   - **Examples**:
>     - Modified example captions in `PROMPT` to include text transcription and styling details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=replicate%2Fflux-fine-tuner&utm_source=github&utm_medium=referral)<sup> for ff903c96f8d9851c774f335e8782b1a208746c46. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->