### PR TITLE
changing params to go fast on H200s

### DIFF
--- a/train.py
+++ b/train.py
@@ -228,6 +228,7 @@ def train(
                 + "\n".join(available_layers_to_optimize)
             )
     quantize = False
+    resolutions = [int(res) for res in resolution.split(",")]
 
     sample_prompts = []
     if wandb_sample_prompts:
@@ -241,6 +242,9 @@ def train(
             print("Turning gradient checkpointing on and quantizing base model, GPU has less than 100 GB of memory")
             gradient_checkpointing = True
             quantize = True
+        elif max(resolutions) > 1024:
+            print("Turning gradient checkpointing on; training resolution greater than 1024x1024")
+            gradient_checkpointing = True
 
     train_config = OrderedDict(
         {
@@ -274,9 +278,7 @@ def train(
                                 # TODO: Do we need to cache to disk? It's faster not to.
                                 "cache_latents_to_disk": cache_latents_to_disk,
                                 "cache_latents": True,
-                                "resolution": [
-                                    int(res) for res in resolution.split(",")
-                                ],
+                                "resolution": resolutions,
                             }
                         ],
                         "train": {

--- a/train.py
+++ b/train.py
@@ -163,7 +163,7 @@ def train(
     ),
     gradient_checkpointing: bool = Input(
         description="Turn on gradient checkpointing; saves memory at the cost of training speed. Automatically enabled for batch sizes > 1.",
-        default=False
+        default=False,
     ),
     hf_repo_id: str = Input(
         description="Hugging Face repository ID, if you'd like to upload the trained LoRA to Hugging Face. For example, lucataco/flux-dev-lora. If the given repo does not exist, a new public repo will be created.",
@@ -235,15 +235,21 @@ def train(
         sample_prompts = [p.strip() for p in wandb_sample_prompts.split("\n")]
 
     if not gradient_checkpointing:
-        if torch.cuda.get_device_properties(0).total_memory < 1024 * 1024 * 1024 * 100: # memory > 100 GB?
-            print("Turning gradient checkpointing on and quantizing base model, GPU has less than 100 GB of memory")
+        if (
+            torch.cuda.get_device_properties(0).total_memory < 1024 * 1024 * 1024 * 100   # memory < 100 GB?
+        ):  
+            print(
+                "Turning gradient checkpointing on and quantizing base model, GPU has less than 100 GB of memory"
+            )
             gradient_checkpointing = True
             quantize = True
         elif batch_size > 1:
             print("Turning gradient checkpointing on automatically for batch size > 1")
             gradient_checkpointing = True
         elif max(resolutions) > 1024:
-            print("Turning gradient checkpointing on; training resolution greater than 1024x1024")
+            print(
+                "Turning gradient checkpointing on; training resolution greater than 1024x1024"
+            )
             gradient_checkpointing = True
 
     train_config = OrderedDict(

--- a/train.py
+++ b/train.py
@@ -235,13 +235,13 @@ def train(
         sample_prompts = [p.strip() for p in wandb_sample_prompts.split("\n")]
 
     if not gradient_checkpointing:
-        if batch_size > 1:
-            print("Turning gradient checkpointing on automatically for batch size > 1")
-            gradient_checkpointing = True
-        elif torch.cuda.get_device_properties(0).total_memory < 1024 * 1024 * 1024 * 100: # memory > 100 GB?
+        if torch.cuda.get_device_properties(0).total_memory < 1024 * 1024 * 1024 * 100: # memory > 100 GB?
             print("Turning gradient checkpointing on and quantizing base model, GPU has less than 100 GB of memory")
             gradient_checkpointing = True
             quantize = True
+        elif batch_size > 1:
+            print("Turning gradient checkpointing on automatically for batch size > 1")
+            gradient_checkpointing = True
         elif max(resolutions) > 1024:
             print("Turning gradient checkpointing on; training resolution greater than 1024x1024")
             gradient_checkpointing = True

--- a/train.py
+++ b/train.py
@@ -161,6 +161,10 @@ def train(
         description="Regular expression to match specific layers to optimize. Optimizing fewer layers results in shorter training times, but can also result in a weaker LoRA. For example, To target layers 7, 12, 16, 20 which seems to create good likeness with faster training (as discovered by lux in the Ostris discord, inspired by The Last Ben), use `transformer.single_transformer_blocks.(7|12|16|20).proj_out`.",
         default=None,
     ),
+    gradient_checkpointing: bool = Input(
+        descripton="Turn on gradient checkpointing; saves memory at the cost of training speed. Automatically enabled for batch sizes > 1.",
+        default=False
+    ),
     hf_repo_id: str = Input(
         description="Hugging Face repository ID, if you'd like to upload the trained LoRA to Hugging Face. For example, lucataco/flux-dev-lora. If the given repo does not exist, a new public repo will be created.",
         default=None,
@@ -223,10 +227,20 @@ def train(
                 f"The regex '{layers_to_optimize_regex}' didn't match any layers. These layers can be optimized:\n"
                 + "\n".join(available_layers_to_optimize)
             )
+    quantize = False
 
     sample_prompts = []
     if wandb_sample_prompts:
         sample_prompts = [p.strip() for p in wandb_sample_prompts.split("\n")]
+
+    if not gradient_checkpointing:
+        if batch_size > 1:
+            print("Turning gradient checkpointing on automatically for batch size > 1")
+            gradient_checkpointing = True
+        elif torch.cuda.get_device_properties(0).total_memory < 1024 * 1024 * 1024 * 100: # memory > 100 GB?
+            print("Turning gradient checkpointing on and quantizing base model, GPU has less than 100 GB of memory")
+            gradient_checkpointing = True
+            quantize = True
 
     train_config = OrderedDict(
         {
@@ -272,7 +286,7 @@ def train(
                             "train_unet": True,
                             "train_text_encoder": False,
                             "content_or_style": "balanced",
-                            "gradient_checkpointing": True,
+                            "gradient_checkpointing": gradient_checkpointing,
                             "noise_scheduler": "flowmatch",
                             "optimizer": optimizer,
                             "lr": learning_rate,
@@ -282,7 +296,7 @@ def train(
                         "model": {
                             "name_or_path": str(WEIGHTS_PATH),
                             "is_flux": True,
-                            "quantize": True,
+                            "quantize": quantize,
                         },
                         "sample": {
                             "sampler": "flowmatch",

--- a/train.py
+++ b/train.py
@@ -162,7 +162,7 @@ def train(
         default=None,
     ),
     gradient_checkpointing: bool = Input(
-        descripton="Turn on gradient checkpointing; saves memory at the cost of training speed. Automatically enabled for batch sizes > 1.",
+        description="Turn on gradient checkpointing; saves memory at the cost of training speed. Automatically enabled for batch sizes > 1.",
         default=False
     ),
     hf_repo_id: str = Input(

--- a/train.py
+++ b/train.py
@@ -236,8 +236,9 @@ def train(
 
     if not gradient_checkpointing:
         if (
-            torch.cuda.get_device_properties(0).total_memory < 1024 * 1024 * 1024 * 100   # memory < 100 GB?
-        ):  
+            torch.cuda.get_device_properties(0).total_memory
+            < 1024 * 1024 * 1024 * 100  # memory < 100 GB?
+        ):
             print(
                 "Turning gradient checkpointing on and quantizing base model, GPU has less than 100 GB of memory"
             )


### PR DESCRIPTION
In order to speed up training (losslessly!) in default situations on Replicate, I'm making a few tradeoffs for increased speed at the cost of increased memory usage. specifically:

- turning off gradient checkpointing
- not quantizing the flux DiT
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Optimize training speed on H200s by disabling gradient checkpointing and model quantization under specific conditions in `train.py`.
> 
>   - **Behavior**:
>     - Disable gradient checkpointing by default in `train()` to increase training speed.
>     - Automatically enable gradient checkpointing if GPU memory < 100GB, batch size > 1, or resolution > 1024.
>     - Disable model quantization by default; enable if GPU memory < 100GB.
>   - **Parameters**:
>     - Add `gradient_checkpointing` parameter to `train()` with default `False`.
>     - Set `quantize` to `False` by default in `train()`.
>   - **Misc**:
>     - Refactor resolution parsing in `train()` to use `resolutions` list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=replicate%2Fflux-fine-tuner&utm_source=github&utm_medium=referral)<sup> for db8150447068be5cb855fef81522d6fc9ab2fa66. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->