### PR TITLE
ignore safe push & template

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,3 +25,5 @@ output
 input_images
 falcon-cache
 safety-cache
+
+cog-safe-push.*


### PR DESCRIPTION
don't build safe-push config into the actual docker image, we only need it for CI/CD
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `cog-safe-push.*` to `.dockerignore` to exclude from Docker image builds, needed only for CI/CD.
> 
>   - **Docker Ignore**:
>     - Add `cog-safe-push.*` to `.dockerignore` to exclude these files from Docker image builds, as they are only needed for CI/CD.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=replicate%2Fflux-fine-tuner&utm_source=github&utm_medium=referral)<sup> for e3b4602bd6ab3b264c27aca66e37d8289f34d981. You can [customize](https://app.ellipsis.dev/replicate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->